### PR TITLE
fix(docs): render Recommended badge as a component so prod MDX doesn'…

### DIFF
--- a/app/icons/docs/_components/Badge.tsx
+++ b/app/icons/docs/_components/Badge.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+/**
+ * Small inline pill for MDX (e.g. "Recommended"). Rendered as a component so
+ * MDX never re-parses its text into a block <p>. The `[&_p]` guard flattens
+ * any <p> the production MDX build still injects, so it stays a tight inline
+ * pill in both the Turbopack dev server and the webpack production build.
+ */
+const Badge: React.FC<{ children: ReactNode }> = ({ children }) => (
+	<span className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 mr-2 inline-block rounded-full border px-2.5 py-0.5 align-middle text-xs font-semibold [&_p]:m-0! [&_p]:inline [&_p]:text-inherit [&_p]:leading-none">
+		{children}
+	</span>
+);
+
+export default Badge;

--- a/app/icons/docs/_components/Callout.tsx
+++ b/app/icons/docs/_components/Callout.tsx
@@ -46,7 +46,7 @@ export function Callout({
 			)}
 		>
 			<Icon className={cn("mt-0.5 size-4.5 shrink-0", s.icon_)} />
-			<div className="text-textSecondary leading-7 [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&>p]:my-0">
+			<div className="text-textSecondary leading-7 [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&_p]:my-0!">
 				{children}
 			</div>
 		</div>

--- a/app/icons/docs/mcp/page.mdx
+++ b/app/icons/docs/mcp/page.mdx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import CodeBlock from "../../_components/docs/CodeBlock";
 import { Callout } from "../_components/Callout";
 
@@ -30,7 +29,7 @@ export const mcpUsageCode = `// Then just ask your agent in plain language:
 
 # MCP server
 
-`@animateicons/mcp` is a <Link href="https://modelcontextprotocol.io" target="_blank">Model Context Protocol</Link> server. Connect it to an AI coding agent (Claude Code, Cursor, and others), and the agent can search the AnimateIcons catalog and drop animated icons straight into your project, no copy-pasting.
+`@animateicons/mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server. Connect it to an AI coding agent (Claude Code, Cursor, and others), and the agent can search the AnimateIcons catalog and drop animated icons straight into your project, no copy-pasting.
 
 <div className="space-y-14">
 
@@ -80,10 +79,10 @@ Add the server to your MCP config (e.g. `.cursor/mcp.json` or `.mcp.json`):
 ## Requirements
 
 <Callout type="note">
-Icons written by `add_icon` import `cn` from `@/lib/utils` (the shadcn convention) and require the <Link href="https://motion.dev" target="_blank">motion</Link> package at runtime.
+Icons written by `add_icon` import `cn` from `@/lib/utils` (the shadcn convention) and require the [motion](https://motion.dev) package at runtime.
 </Callout>
 
-Prefer the terminal? The <Link href="/icons/docs/cli">CLI</Link> does the same thing with `npx animateicons add`.
+Prefer the terminal? The [CLI](/icons/docs/cli) does the same thing with `npx animateicons add`.
 
 </section>
 

--- a/app/icons/docs/page.mdx
+++ b/app/icons/docs/page.mdx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import CodeBlock from "../_components/docs/CodeBlock";
 import CommandBlock from "../_components/docs/CommandBlock";
 import Badge from "./_components/Badge";
@@ -57,9 +56,9 @@ Icons animate on hover out of the box, no extra wiring. Pass `size`, `color`, or
 
 ## Prefer to copy the source?
 
-If you'd rather own the icon files instead of depending on the package, use the <Link href="/icons/docs/shadcn">shadcn CLI</Link> or the first-party <Link href="/icons/docs/cli">animateicons CLI</Link>. Using an AI coding agent? The <Link href="/icons/docs/mcp">MCP server</Link> lets it add icons for you.
+If you'd rather own the icon files instead of depending on the package, use the [shadcn CLI](/icons/docs/shadcn) or the first-party [animateicons CLI](/icons/docs/cli). Using an AI coding agent? The [MCP server](/icons/docs/mcp) lets it add icons for you.
 
-Once icons are in your project, head to <Link href="/icons/docs/usage">Usage</Link> for styling, the imperative API, and full types.
+Once icons are in your project, head to [Usage](/icons/docs/usage) for styling, the imperative API, and full types.
 
 </section>
 

--- a/app/icons/docs/page.mdx
+++ b/app/icons/docs/page.mdx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import CodeBlock from "../_components/docs/CodeBlock";
 import CommandBlock from "../_components/docs/CommandBlock";
+import Badge from "./_components/Badge";
 import { Callout } from "./_components/Callout";
 import InstallMethods from "./_components/InstallMethods";
 import { ICON_COUNTS } from "@/lib/icon-count.generated";
@@ -32,7 +33,7 @@ Pick whichever path fits your setup. They all ship the same icons and the same A
 
 ## npm package
 
-<span className="border-emerald-500/30 bg-emerald-500/10 text-emerald-400 mr-2 inline-block rounded-full border px-2.5 py-0.5 align-middle text-xs font-semibold">Recommended</span> Best for most apps. One install, all {ICON_COUNTS.total} icons available.
+<Badge>Recommended</Badge> Best for most apps. One install, all {ICON_COUNTS.total} icons available.
 
 #### 1. Install the package
 

--- a/app/icons/docs/shadcn/page.mdx
+++ b/app/icons/docs/shadcn/page.mdx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import CodeBlock from "../../_components/docs/CodeBlock";
 
 export const metadata = {
@@ -24,11 +23,11 @@ Use this if you want each icon copied into your codebase as a single file you ca
 
 #### 1. Set up shadcn
 
-If your project doesn't have shadcn yet, follow the <Link href="https://ui.shadcn.com/docs/installation" target="_blank">shadcn installation guide</Link> first.
+If your project doesn't have shadcn yet, follow the [shadcn installation guide](https://ui.shadcn.com/docs/installation) first.
 
 #### 2. Add an icon
 
-Browse the <Link href="/icons/lucide">Lucide</Link> or <Link href="/icons/huge">Huge</Link> gallery, click any tile to copy its install command, or replace `lu-eye` below with the icon you want.
+Browse the [Lucide](/icons/lucide) or [Huge](/icons/huge) gallery, click any tile to copy its install command, or replace `lu-eye` below with the icon you want.
 
 <CodeBlock code={installCode} lang="bash" title="Terminal" />
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types";
+import Link from "next/link";
 import type { ReactNode } from "react";
 
 /**
@@ -78,16 +79,30 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
 		p: ({ children }) => (
 			<p className="text-textSecondary my-4 text-sm leading-7">{children}</p>
 		),
-		a: ({ href, children }) => (
-			<a
-				href={href}
-				className="text-primary font-medium underline decoration-white/25 underline-offset-4 transition-colors hover:decoration-current"
-				target={href?.startsWith("http") ? "_blank" : undefined}
-				rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
-			>
-				{children}
-			</a>
-		),
+		a: ({ href, children }) => {
+			const cls =
+				"text-primary font-medium underline decoration-white/25 underline-offset-4 transition-colors hover:decoration-current";
+			// Internal routes use next/link for client-side nav; external opens
+			// in a new tab. Authored as markdown links in MDX so they stay inline
+			// (a JSX <Link> in prose gets block-split by the prod MDX build).
+			if (href?.startsWith("http")) {
+				return (
+					<a
+						href={href}
+						className={cls}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{children}
+					</a>
+				);
+			}
+			return (
+				<Link href={href ?? "#"} className={cls}>
+					{children}
+				</Link>
+			);
+		},
 		strong: ({ children }) => (
 			<strong className="text-textPrimary font-semibold">{children}</strong>
 		),


### PR DESCRIPTION
…t wrap it in <p>

The webpack production build wraps inline MDX (<span> badge, Callout text) in <p>, inheriting the p override's my-4 margin and inflating it; Turbopack dev keeps it inline so it only broke on prod. Move the badge to a Badge component and harden the Callout guard with [&_p]:my-0!.