### PR TITLE
chore(release): bump @animateicons/react to 0.4.3

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@animateicons/react",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"description": "Animated SVG icons for React with hover and imperative animation triggers. Built on motion/react.",
 	"license": "MIT",
 	"author": "Avijit Dey",


### PR DESCRIPTION
npm treats published versions as immutable, so 0.4.2's stale 326-icon README can't be updated in place. Republish as 0.4.3 to surface the corrected 542 count (README fix already merged to main).