### PR TITLE
fix(search): cap query length and skip unmatchable searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ next-env.d.ts
 .hive-mind/
 ruvector.db
 CLAUDE.md
+CLAUDE.local.md
+.mcp.json

--- a/app/icons/_components/navbar/SearchBar.tsx
+++ b/app/icons/_components/navbar/SearchBar.tsx
@@ -11,7 +11,10 @@ import { ICON_COUNT as HUGE_ICON_COUNT } from "@/icons/huge/meta";
 import { ICON_COUNT as LUCIDE_ICON_COUNT } from "@/icons/lucide/meta";
 import { SearchIcon } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
-import { useIconSearch } from "../../_contexts/IconSearchContext";
+import {
+	MAX_SEARCH_LENGTH,
+	useIconSearch,
+} from "../../_contexts/IconSearchContext";
 
 const isMac =
 	typeof navigator !== "undefined" &&
@@ -58,6 +61,7 @@ const SearchBar: React.FC<Props> = () => {
 				<InputGroupInput
 					ref={inputRef}
 					value={query}
+					maxLength={MAX_SEARCH_LENGTH}
 					placeholder={`Search ${ICON_COUNT} icons...`}
 					onChange={(e) => setQuery(e.target.value)}
 					onFocus={() => setFocused(true)}

--- a/app/icons/_contexts/IconSearchContext.tsx
+++ b/app/icons/_contexts/IconSearchContext.tsx
@@ -19,11 +19,16 @@
  *   URL → state fires only when the URL drifts from the debounced
  *         value (i.e. only on real navigation, not on our own
  *         router.replace)
+ *
+ * Every path into `query` - hydration, setQuery, and inbound URL drift -
+ * is clamped to MAX_SEARCH_LENGTH so a pasted wall of text can't reach
+ * the URL and stall the page (#45).
  */
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import React, {
 	createContext,
+	useCallback,
 	useContext,
 	useEffect,
 	useMemo,
@@ -47,6 +52,8 @@ const IconSearchInputContext =
 const IconSearchResultContext =
 	createContext<IconSearchResultContextValue | null>(null);
 
+export const MAX_SEARCH_LENGTH = 100;
+
 export const IconSearchProvider: React.FC<{
 	children: React.ReactNode;
 }> = ({ children }) => {
@@ -57,7 +64,7 @@ export const IconSearchProvider: React.FC<{
 	// Hydrate from `?q=` on first render. Lazy init so we don't read
 	// searchParams on every render - and so SSR/CSR start matches.
 	const [query, setQuery] = useState(
-		() => searchParams?.get(QUERY_PARAM) ?? "",
+		() => searchParams?.get(QUERY_PARAM)?.slice(0, MAX_SEARCH_LENGTH) ?? "",
 	);
 	const [debouncedQuery] = useDebounce(query, 300);
 
@@ -65,11 +72,12 @@ export const IconSearchProvider: React.FC<{
 	useEffect(() => {
 		if (!searchParams) return;
 		const current = searchParams.get(QUERY_PARAM) ?? "";
-		if (debouncedQuery === current) return;
+		const safeQuery = debouncedQuery.slice(0, MAX_SEARCH_LENGTH);
+		if (safeQuery === current) return;
 
 		const params = new URLSearchParams(searchParams.toString());
-		if (debouncedQuery) {
-			params.set(QUERY_PARAM, debouncedQuery);
+		if (safeQuery) {
+			params.set(QUERY_PARAM, safeQuery);
 		} else {
 			params.delete(QUERY_PARAM);
 		}
@@ -87,13 +95,26 @@ export const IconSearchProvider: React.FC<{
 	const [prevKey, setPrevKey] = useState(searchParamsKey);
 	if (searchParamsKey !== prevKey) {
 		setPrevKey(searchParamsKey);
-		const urlQuery = searchParams?.get(QUERY_PARAM) ?? "";
+		const rawUrlQuery = searchParams?.get(QUERY_PARAM) ?? "";
+		const urlQuery = rawUrlQuery.slice(0, MAX_SEARCH_LENGTH);
 		if (urlQuery !== debouncedQuery && urlQuery !== query) {
 			setQuery(urlQuery);
 		}
 	}
 
-	const inputValue = useMemo(() => ({ query, setQuery }), [query]);
+	const handleSetQuery = useCallback<
+		React.Dispatch<React.SetStateAction<string>>
+	>((action) => {
+		setQuery((prev) => {
+			const next = typeof action === "function" ? action(prev) : action;
+			return next.slice(0, MAX_SEARCH_LENGTH);
+		});
+	}, []);
+
+	const inputValue = useMemo(
+		() => ({ query, setQuery: handleSetQuery }),
+		[query, handleSetQuery],
+	);
 	const resultValue = useMemo(() => ({ debouncedQuery }), [debouncedQuery]);
 
 	return (

--- a/components/command-search/CommandSearch.tsx
+++ b/components/command-search/CommandSearch.tsx
@@ -16,8 +16,13 @@
  * set is fine to filter, but rendering that many motion components
  * with hover handlers is not. Limit is generous enough that any real
  * query narrows long before hitting it.
+ *
+ * Input is capped at MAX_SEARCH_LENGTH, and queries longer than
+ * MAX_MATCHABLE_LENGTH skip the Fuse search entirely - it can't match,
+ * and its cost scales with pattern length (#45).
  */
 
+import { MAX_SEARCH_LENGTH } from "@/app/icons/_contexts/IconSearchContext";
 import { Kbd } from "@/components/ui/kbd";
 import {
 	getIcon as getHugeIcon,
@@ -72,17 +77,27 @@ const FUSE = new Fuse(ALL_ICONS, {
 	includeScore: true,
 });
 
+const MAX_MATCHABLE_LENGTH = [...LUCIDE_META, ...HUGE_META].reduce(
+	(max, icon) => {
+		const longestKeyword = (icon.keywords ?? []).reduce(
+			(longest, keyword) => Math.max(longest, keyword.length),
+			0,
+		);
+		return Math.max(max, icon.name.length, longestKeyword);
+	},
+	0,
+);
+
 const CommandSearch: React.FC<Props> = ({ isOpen, onClose }) => {
 	const [query, setQuery] = useState("");
 	const [selected, setSelected] = useState(0);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const router = useRouter();
 
-	// Filter + rank. Empty query → first MAX_RESULTS icons (alphabetical
-	// from the source). Otherwise: prefix matches first, then fuse.
 	const results = useMemo<CommandSearchIcon[]>(() => {
 		const q = query.trim().toLowerCase();
 		if (q.length < 2) return ALL_ICONS.slice(0, MAX_RESULTS);
+		if (q.length > MAX_MATCHABLE_LENGTH) return [];
 
 		const exact: CommandSearchIcon[] = [];
 		const startsWith: CommandSearchIcon[] = [];
@@ -232,8 +247,11 @@ const CommandSearch: React.FC<Props> = ({ isOpen, onClose }) => {
 							<input
 								ref={inputRef}
 								type="text"
+								maxLength={MAX_SEARCH_LENGTH}
 								value={query}
-								onChange={(e) => setQuery(e.target.value)}
+								onChange={(e) =>
+									setQuery(e.target.value.slice(0, MAX_SEARCH_LENGTH))
+								}
 								placeholder="Search icons by name or keyword…"
 								className="text-textPrimary placeholder:text-textMuted flex-1 bg-transparent text-sm outline-none"
 								autoComplete="off"

--- a/hooks/useIconFilter.ts
+++ b/hooks/useIconFilter.ts
@@ -8,6 +8,10 @@
  * "bell-ring" before "doorbell") with a Fuse.js fuzzy fallback for
  * typos. Also flags icons added in the last three days as `isNew` so
  * the gallery can decorate them.
+ *
+ * Queries longer than the longest matchable name or keyword bail out
+ * before reaching Fuse, whose cost scales with pattern length - that
+ * search is what froze the page on a large paste (#45).
  */
 
 import { isIconNew } from "@/utils/isIconNew";
@@ -34,6 +38,17 @@ export const useIconSearchFilter = ({
 		return icons.filter((icon) => icon.category?.includes(category));
 	}, [icons, category]);
 
+	const maxMatchableLength = useMemo(() => {
+		let max = 0;
+		for (const icon of icons) {
+			max = Math.max(max, icon.name.length);
+			for (const keyword of icon.keywords ?? []) {
+				max = Math.max(max, keyword.length);
+			}
+		}
+		return max;
+	}, [icons]);
+
 	const fuse = useMemo(() => {
 		if (!icons.length) return null;
 
@@ -53,6 +68,8 @@ export const useIconSearchFilter = ({
 		if (!categoryIcons.length) return [];
 
 		const q = query.trim().toLowerCase();
+		if (q.length > maxMatchableLength) return [];
+
 		let items = categoryIcons;
 
 		if (q.length >= 2) {
@@ -103,7 +120,7 @@ export const useIconSearchFilter = ({
 				isNew: isIconNew(item.addedAt),
 			}))
 			.sort((a, b) => Number(b.isNew) - Number(a.isNew));
-	}, [query, fuse, categoryIcons, category]);
+	}, [query, fuse, categoryIcons, category, maxMatchableLength]);
 
 	return filteredItems;
 };

--- a/tests/contexts/IconSearchContext.test.tsx
+++ b/tests/contexts/IconSearchContext.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for IconSearchContext - manages query state, debouncing,
+ * and URL synchronization while guarding against oversized queries.
+ */
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import {
+	IconSearchProvider,
+	MAX_SEARCH_LENGTH,
+	useIconSearch,
+	useIconSearchResult,
+} from "@/app/icons/_contexts/IconSearchContext";
+
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		replace: mockReplace,
+	}),
+	usePathname: () => "/icons/lucide",
+	useSearchParams: () => mockSearchParams,
+}));
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+	<IconSearchProvider>{children}</IconSearchProvider>
+);
+
+describe("IconSearchContext", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSearchParams = new URLSearchParams();
+	});
+
+	it("hydrates empty query when searchParams has no q", () => {
+		const { result } = renderHook(() => useIconSearch(), { wrapper });
+		expect(result.current.query).toBe("");
+	});
+
+	it("hydrates from searchParams on mount", () => {
+		mockSearchParams = new URLSearchParams("q=bell");
+		const { result } = renderHook(() => useIconSearch(), { wrapper });
+		expect(result.current.query).toBe("bell");
+	});
+
+	it("truncates oversized query hydrated from searchParams to MAX_SEARCH_LENGTH", () => {
+		const hugeQuery = "a".repeat(500);
+		mockSearchParams = new URLSearchParams(`q=${hugeQuery}`);
+		const { result } = renderHook(() => useIconSearch(), { wrapper });
+		expect(result.current.query).toHaveLength(MAX_SEARCH_LENGTH);
+		expect(result.current.query).toBe("a".repeat(MAX_SEARCH_LENGTH));
+	});
+
+	it("clamps query when setQuery is called with long string", () => {
+		const { result } = renderHook(() => useIconSearch(), { wrapper });
+		act(() => {
+			result.current.setQuery("b".repeat(300));
+		});
+		expect(result.current.query).toHaveLength(MAX_SEARCH_LENGTH);
+		expect(result.current.query).toBe("b".repeat(MAX_SEARCH_LENGTH));
+	});
+
+	it("clamps query when setQuery is called with function updater", () => {
+		const { result } = renderHook(() => useIconSearch(), { wrapper });
+		act(() => {
+			result.current.setQuery(() => "c".repeat(300));
+		});
+		expect(result.current.query).toHaveLength(MAX_SEARCH_LENGTH);
+		expect(result.current.query).toBe("c".repeat(MAX_SEARCH_LENGTH));
+	});
+
+	it("rewrites an oversized inbound ?q= down to MAX_SEARCH_LENGTH in the URL", async () => {
+		const hugeQuery = "a".repeat(5000);
+		mockSearchParams = new URLSearchParams(`q=${hugeQuery}`);
+		renderHook(() => useIconSearch(), { wrapper });
+
+		await vi.waitFor(() => expect(mockReplace).toHaveBeenCalled());
+
+		const [url] = mockReplace.mock.calls.at(-1)!;
+		const replaced = new URLSearchParams(url.split("?")[1]).get("q");
+		expect(replaced).toHaveLength(MAX_SEARCH_LENGTH);
+		expect(url.length).toBeLessThan(hugeQuery.length);
+	});
+
+	it("throws if used outside the provider", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		expect(() => renderHook(() => useIconSearch())).toThrow(
+			"useIconSearch must be used inside IconSearchProvider",
+		);
+		expect(() => renderHook(() => useIconSearchResult())).toThrow(
+			"useIconSearchResult must be used inside IconSearchProvider",
+		);
+		spy.mockRestore();
+	});
+});

--- a/tests/hooks/useIconFilter.test.ts
+++ b/tests/hooks/useIconFilter.test.ts
@@ -64,6 +64,24 @@ describe("useIconSearchFilter", () => {
 		expect(result.current).toHaveLength(3);
 	});
 
+	it("short-circuits queries longer than any matchable name or keyword", () => {
+		const { result } = renderHook(() =>
+			useIconSearchFilter({
+				icons: ICONS,
+				category: "all",
+				query: "a".repeat(50),
+			}),
+		);
+		expect(result.current).toHaveLength(0);
+	});
+
+	it("still matches a query as long as the longest keyword", () => {
+		const { result } = renderHook(() =>
+			useIconSearchFilter({ icons: ICONS, category: "all", query: "profile" }),
+		);
+		expect(result.current.map((i) => i.name)).toContain("user");
+	});
+
 	it("returns empty array when no icon matches", () => {
 		const { result } = renderHook(() =>
 			useIconSearchFilter({


### PR DESCRIPTION
Pasting a large amount of text into the search input froze the page. The full pasted string was written to the `?q=` URL param on every debounce and handed to Fuse.js, whose bitap cost scales with pattern length - so a multi-KB paste produced a multi-KB URL and a search that blocked the main thread for tens of milliseconds per keystroke.

- Clamp every path into the query state (hydration, setQuery, and inbound URL drift) to MAX_SEARCH_LENGTH, and cap both search inputs with maxLength so oversized values never reach the URL.
- Skip the Fuse search entirely when a query is longer than the longest matchable icon name or keyword: it cannot match, so the work is wasted. The threshold is derived from the catalog rather than hardcoded, so it cannot drift as icons are added.
- Add tests covering the URL rewrite, the short-circuit, and a regression guard that keyword-length queries still match.

Closes #45